### PR TITLE
README update template showcase

### DIFF
--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,0 @@
-A fully-loaded toolkit to build Phase2 projects and interact via the command-line interface.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-![logo](https://www.phase2technology.com/wp-content/uploads/2015/06/logo-retina.png)
+# Outrigger Build
 
-## Description
+> The Outrigger Build image provides a command-line toolkit for PHP & Node development with Drupal support.
+
+[![](https://images.microbadger.com/badges/version/outrigger/build.svg)](https://microbadger.com/images/outrigger/build "Get your own version badge on microbadger.com")
+[![](https://images.microbadger.com/badges/image/outrigger/build.svg)](https://microbadger.com/images/outrigger/build "Get your own image badge on microbadger.com")
 
 This image provides the many development tools necessary to build applications
 the Outrigger way, bundled with a wide array of tools useful for development and
@@ -11,16 +14,19 @@ Contains everything you need to work with Drupal, including use of tools such as
 [Grunt-Drupal-Tasks](https://github.com/phase2/grunt-drupal-tasks) and
 [Pattern Lab Starter](https://github.com/phase2/pattern-lab-starter/).
 
-## Available Packages & Tools
+For more documentation on how Outrigger images are constructed and how to work
+with them, please [see the documentation](http://docs.outrigger.sh/en/latest/).
+
+## Features
 
 * Out of the box support for PHP (version based on tag), Ruby 1.9.3 and Node versions
 4.x (LTS), 5.x (stable) and 6.x (LTS) based on environment toggle (see below).
-* Global availability of Composer, NPM, Bower, Grunt, and Yeoman.
+* Global availability of Composer, Drush, Drupal Console, NPM, Bower, Grunt, Gulp, and Yeoman.
 
 For more details of specific packages, libraries, and utilities, please see the
 [Dockerfile](https://github.com/phase2/docker-build/blob/php70/Dockerfile).
 
-## Drush (Drupal Shell) Configuration
+### Drush (Drupal Shell) Integration
 
 There is global configuration for Drush at `/etc/drush/drushrc.php`.
 
@@ -35,32 +41,24 @@ Default configuration in this file provides the following:
 
 * **Registry Rebuild**: `drush rr` is included by default.
 
-## Environment Variables
-When you start the outrigger/build image, you can adjust the configuration of the
-build instance by passing one or more environment variables on the docker run
-command-line or via your docker-compose manifest file.
-
-Additional environment variables for commonly customized settings will be considered.
-
-### NODE_VERSION
-
-Specify the version of Node.js to use.
-
-* **Default**: `4`
-* **Node 5.x**: `5`
-* **Node 6.x**: `6`
-
-### PHP_XDEBUG
-
-Specify if the xdebug extension should be enabled
-
-* **Default**: "false"
-* **Enable xdebug**: "true"
-
-## Other Conveniences
-
-### Bash history persistence between invocations
+### BASH History Persistence
 
 If you would like your bash history preserved, provide a volume mount to a persistent
 data location at /root/bash and initialization scripts will ensure your .bash\_history
 file is written there. For example `/data/PROJECT/bash:/root/bash`
+
+## Environment Variables
+
+Outrigger images use Environment Variables and [confd](https://github.com/kelseyhightower/confd)
+to templatize a number of Docker environment configurations. These templates are
+processed on startup with environment variables passed in via the docker run
+command-line or via your docker-compose manifest file. Here are the "tunable"
+configurations offered by this image.
+
+* `NODE_VERSION`: [`4`|`5`|`6`] Defaults to 4. Selects the major version of Node
+  to make available to all tools via nvm. The latest minor release as of the image build will be used.
+* `PHP_XDEBUG`: ["true"|"false"] Specify whether the PHP Xdebug extension should be enabled.
+
+## Maintainers
+
+[![Phase2 Logo](https://www.phase2technology.com/wp-content/uploads/2015/06/logo-retina.png)](https://www.phase2technology.com)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ configurations offered by this image.
 
 * `NODE_VERSION`: [`4`|`5`|`6`] Defaults to 4. Selects the major version of Node
   to make available to all tools via nvm. The latest minor release as of the image build will be used.
-* `PHP_XDEBUG`: ["true"|"false"] Specify whether the PHP Xdebug extension should be enabled.
+* `PHP_XDEBUG`: [`"true"`|`"false"`] Specify whether the PHP Xdebug extension should be enabled.
 
 ## Maintainers
 


### PR DESCRIPTION
This updates the README to match the proposed Outrigger Docker Image template at https://github.com/phase2/outrigger-docs/wiki/Docker-Image-README-Template, sans Security contact info.

Included is the MicroBadger badge, which automatically goes to the default branch, which has apparently switched from php70 to php71.