### PR TITLE
Enable git preloadindex by default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,10 @@ ENV PKG_CONFIG_PATH /opt/rh/ruby193/root/usr/lib64/pkgconfig
 # Ensure $HOME is set
 ENV HOME /root
 
+# Configure Git
+# https://git-scm.com/docs/git-config#git-config-corepreloadIndex
+RUN git config --global core.preloadindex true
+
 # Install Composer
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/bin/composer
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser


### PR DESCRIPTION
The git configuration setting makes commands such as `git status` and `git diff` faster by using threads for concurrent IO. This is massively helpful when running git commands over NFS, such as via a Docker container with NFS volume mounts.

In the example of a relatively basic Drupal 8 site it took git status down from 16 seconds to 3 seconds.

Furthermore, Linus has [suggested this should be the default enabled setting](http://git.661346.n2.nabble.com/git-status-takes-30-seconds-on-Windows-7-Why-td7580816.html#a7580853), if only the availability of functional threading could be guaranteed.