### PR TITLE
Add phpredis and some other fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN yum -y install \
       nmap-ncat \
       patch \
       php71 \
+      php71-php-devel \
       php71-php-gd \
       php71-php-xml \
       php71-php-pdo \
@@ -60,6 +61,17 @@ ENV PATH /root/.composer/vendor/bin:/opt/rh/ruby193/root/usr/bin:/usr/local/sbin
 RUN ln -sfv /opt/remi/php71/root/usr/bin/* /usr/bin/ && \
     ln -sfv /opt/remi/php71/root/usr/sbin/* /usr/sbin/
 
+# Install PHPRedis extension
+ENV PHPREDIS_VERSION 3.1.2
+RUN curl -L -o /tmp/phpredis.tar.gz "https://github.com/phpredis/phpredis/archive/$PHPREDIS_VERSION.tar.gz" && \
+    tar -xzf /tmp/phpredis.tar.gz -C /tmp && \
+    rm /tmp/phpredis.tar.gz && \
+    cd "/tmp/phpredis-$PHPREDIS_VERSION" && \
+    phpize && \
+    ./configure && \
+    make && \
+    make install
+
 # Enable other ruby193 SCL config
 ENV LD_LIBRARY_PATH /opt/rh/ruby193/root/usr/lib64
 ENV PKG_CONFIG_PATH /opt/rh/ruby193/root/usr/lib64/pkgconfig
@@ -75,12 +87,6 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 # Install Drush
 RUN composer global require drush/drush:8.x
 
-# Install Drupal Console / Laucher
-RUN composer global require drupal/console:@stable
-RUN curl https://drupalconsole.com/installer -L -o /usr/bin/drupal && chmod +x /usr/bin/drupal
-RUN drupal self-update
-RUN drupal init -n
-
 # Install Prestissimo for composer performance
 RUN composer global require "hirak/prestissimo:^0.3"
 
@@ -90,7 +96,8 @@ RUN composer global update
 # Install nvm, supported node versions, and default cli modules.
 ENV NVM_DIR $HOME/.nvm
 ENV NODE_VERSION 4
-RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
+RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
+RUN chmod +x $HOME/.nvm/nvm.sh
 
 # Node 4.x (LTS)
 RUN source $NVM_DIR/nvm.sh \

--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ configurations offered by this image.
 
 ## Maintainers
 
-[![Phase2 Logo](https://www.phase2technology.com/wp-content/uploads/2015/06/logo-retina.png)](https://www.phase2technology.com)
+[![Phase2 Logo](https://s3.amazonaws.com/phase2.public/logos/phase2-logo.png)](https://www.phase2technology.com)

--- a/root/etc/opt/remi/php71/php.d/90-redis.ini
+++ b/root/etc/opt/remi/php71/php.d/90-redis.ini
@@ -1,0 +1,1 @@
+extension=redis.so

--- a/root/etc/opt/remi/php71/php.ini
+++ b/root/etc/opt/remi/php71/php.ini
@@ -311,7 +311,7 @@ serialize_precision = -1
 ; This directive allows you to disable certain functions for security reasons.
 ; It receives a comma-delimited list of function names.
 ; http://php.net/disable-functions
-disable_functions = pcntl_exec
+disable_functions =
 
 ; This directive allows you to disable certain classes for security reasons.
 ; It receives a comma-delimited list of class names.

--- a/root/versions.sh
+++ b/root/versions.sh
@@ -33,6 +33,3 @@ composer --version
 echo ''
 echo 'Drush version:'
 drush --version
-echo ''
-echo 'Drupal Console version:'
-drupal --version


### PR DESCRIPTION
* Added phpredis (and enabled it)
* Upgraded nvm from 0.33.0 to 0.33.2
* Removed Drupal Console (should now be local dependency)
* Removed `pcntl_exec` from `disabled_fucntions` in `php.ini`, drush installation of registry-rebuild was failing because that function was not enabled. It was originally disabled to prevent the `BASH_FUNC_module` warning message.