### PR TITLE
Improve consistency and ordering of Dockerfiles

### DIFF
--- a/php55/Dockerfile
+++ b/php55/Dockerfile
@@ -17,41 +17,51 @@ RUN yum -y install \
 
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 
+# Add the IUS repository. This is needed for git2.
+RUN curl -L "https://centos7.iuscommunity.org/ius-release.rpm" > /usr/local/ius-release.rpm && \
+    rpm -Uvh /usr/local/ius-release.rpm
+
 RUN yum -y install \
-      bzip2 \
-      gcc-c++ \
-      git \
-      httpd-tools \
-      make \
-      mariadb \
-      nmap-ncat \
-      patch \
-      php55 \
-      php55-php-bcmath \
-      php55-php-cli \
-      php55-php-devel \
-      php55-php-fpm \
-      php55-php-gd \
-      php55-php-mbstring \
-      php55-php-mysql \
-      php55-php-opcache \
-      php55-php-pdo \
-      php55-php-pear \
-      php55-php-pgsql \
-      php55-php-pecl-memcache \
-      php55-php-soap \
-      php55-php-xml \
-      postgresql \
-      rsync \
-      ruby193 \
-      ruby193-rubygems \
-      ruby193-ruby-devel \
-      sendmail \
-      unzip \
-      # Necessary for drush
-      which \
-      # Necessary library for phantomjs per https://github.com/ariya/phantomjs/issues/10904
-      fontconfig
+    # Install PHP
+    php55 \
+    php55-php-bcmath \
+    php55-php-cli \
+    php55-php-devel \
+    php55-php-fpm \
+    php55-php-gd \
+    php55-php-mbstring \
+    php55-php-mysql \
+    php55-php-opcache \
+    php55-php-pdo \
+    php55-php-pear \
+    php55-php-pgsql \
+    php55-php-pecl-memcache \
+    php55-php-soap \
+    php55-php-xml \
+    # Install Ruby
+    ruby193 \
+    ruby193-rubygems \
+    ruby193-ruby-devel
+    # Install Miscellaneous Tools
+    bzip2 \
+    gcc-c++ \
+    git2u-all \
+    httpd-tools \
+    jq \
+    make \
+    mariadb \
+    nmap-ncat \
+    patch \
+    pv \
+    postgresql \
+    rsync \
+    sendmail \
+    unzip \
+    # Necessary for drush
+    which \
+    # Necessary library for phantomjs per https://github.com/ariya/phantomjs/issues/10904
+    fontconfig \
+    && yum clean all
 
 # Ensure php55 and ruby193 binaries are in path
 ENV PATH /root/.composer/vendor/bin:/opt/rh/ruby193/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -66,6 +76,10 @@ ENV PKG_CONFIG_PATH /opt/rh/ruby193/root/usr/lib64/pkgconfig
 
 # Ensure $HOME is set
 ENV HOME /root
+
+# Configure Git
+# https://git-scm.com/docs/git-config#git-config-corepreloadIndex
+RUN git config --global core.preloadindex true
 
 # Install Composer
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/bin/composer

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -11,6 +11,10 @@ RUN curl -L "https://github.com/kelseyhightower/confd/releases/download/v$CONFD_
     chmod +x /usr/bin/confd
 ENV CONFD_OPTS '--backend=env --onetime'
 
+# Add the IUS repository. This is needed for git2.
+RUN curl -L "https://centos7.iuscommunity.org/ius-release.rpm" > /usr/local/ius-release.rpm && \
+    rpm -Uvh /usr/local/ius-release.rpm
+
 RUN yum -y install \
       centos-release-scl-rh \
       https://www.softwarecollections.org/en/scls/remi/php56more/epel-7-x86_64/download/remi-php56more-epel-7-x86_64.noarch.rpm \
@@ -18,41 +22,48 @@ RUN yum -y install \
       https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm && \
     yum -y update
 
+# Add the IUS repository. This is needed for git2.
+RUN curl -L "https://centos7.iuscommunity.org/ius-release.rpm" > /usr/local/ius-release.rpm && \
+    rpm -Uvh /usr/local/ius-release.rpm
+
 RUN yum -y install \
-      bzip2 \
-      gcc-c++ \
-      git \
-      httpd-tools \
-      jq \
-      make \
-      mariadb \
-      nmap-ncat \
-      patch \
-      postgresql \
-      pv \
-      rsync \
-      ruby193 \
-      ruby193-rubygems \
-      ruby193-ruby-devel \
-      sendmail \
-      unzip \
-      # Necessary for drush
-      which \
-      # Necessary library for phantomjs per https://github.com/ariya/phantomjs/issues/10904
-      fontconfig \
-      # Install PHP
-      rh-php56 \
-      rh-php56-php-gd \
-      rh-php56-php-xml \
-      rh-php56-php-pdo \
-      rh-php56-php-mysql \
-      rh-php56-php-mbstring \
-      rh-php56-php-fpm \
-      rh-php56-php-opcache \
-      rh-php56-php-pecl-memcache \
-      rh-php56-php-pecl-xdebug \
-      more-php56-php-mcrypt \
-      more-php56-php-pecl-xhprof
+    # Install PHP
+    rh-php56 \
+    rh-php56-php-gd \
+    rh-php56-php-xml \
+    rh-php56-php-pdo \
+    rh-php56-php-mysql \
+    rh-php56-php-mbstring \
+    rh-php56-php-fpm \
+    rh-php56-php-opcache \
+    rh-php56-php-pecl-memcache \
+    rh-php56-php-pecl-xdebug \
+    more-php56-php-mcrypt \
+    more-php56-php-pecl-xhprof
+    # Install Ruby
+    ruby193 \
+    ruby193-rubygems \
+    ruby193-ruby-devel
+    # Install Miscellaneous Tools
+    bzip2 \
+    gcc-c++ \
+    git2u-all \
+    httpd-tools \
+    jq \
+    make \
+    mariadb \
+    nmap-ncat \
+    patch \
+    postgresql \
+    pv \
+    rsync \
+    sendmail \
+    unzip \
+    # Necessary for drush
+    which \
+    # Necessary library for phantomjs per https://github.com/ariya/phantomjs/issues/10904
+    fontconfig \
+    && yum clean all
 
 # Ensure ruby193 binaries are in path
 ENV PATH /root/.composer/vendor/bin:/opt/rh/ruby193/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -61,12 +72,27 @@ ENV PATH /root/.composer/vendor/bin:/opt/rh/ruby193/root/usr/bin:/usr/local/sbin
 RUN ln -sfv /opt/rh/rh-php56/root/usr/bin/* /usr/bin/ && \
     ln -sfv /opt/rh/rh-php56/root/usr/sbin/* /usr/sbin/
 
+# Install PHPRedis extension
+ENV PHPREDIS_VERSION 3.1.2
+RUN curl -L -o /tmp/phpredis.tar.gz "https://github.com/phpredis/phpredis/archive/$PHPREDIS_VERSION.tar.gz" && \
+    tar -xzf /tmp/phpredis.tar.gz -C /tmp && \
+    rm /tmp/phpredis.tar.gz && \
+    cd "/tmp/phpredis-$PHPREDIS_VERSION" && \
+    phpize && \
+    ./configure && \
+    make && \
+    make install
+
 # Enable other ruby193 SCL config
 ENV LD_LIBRARY_PATH /opt/rh/ruby193/root/usr/lib64
 ENV PKG_CONFIG_PATH /opt/rh/ruby193/root/usr/lib64/pkgconfig
 
 # Ensure $HOME is set
 ENV HOME /root
+
+# Configure Git
+# https://git-scm.com/docs/git-config#git-config-corepreloadIndex
+RUN git config --global core.preloadindex true
 
 # Install Composer
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/bin/composer

--- a/php70/Dockerfile
+++ b/php70/Dockerfile
@@ -22,42 +22,44 @@ RUN curl -L "https://centos7.iuscommunity.org/ius-release.rpm" > /usr/local/ius-
     rpm -Uvh /usr/local/ius-release.rpm
 
 RUN yum -y install \
-      bzip2 \
-      gcc-c++ \
-      git2u-all \
-      httpd-tools \
-      jq \
-      make \
-      mariadb \
-      nmap-ncat \
-      patch \
-      php70 \
-      php70-php-devel \
-      php70-php-gd \
-      php70-php-xml \
-      php70-php-pdo \
-      php70-php-mysql \
-      php70-php-mysqlnd \
-      php70-php-mbstring \
-      php70-php-fpm \
-      php70-php-opcache \
-      php70-php-pecl-memcache \
-      php70-php-pecl-xdebug \
-      php70-php-mcrypt \
-      # There is no PHP 7 support for XHProf yet.
-      # php70-php-pecl-xhprof \
-      postgresql \
-      pv \
-      rsync \
-      ruby193 \
-      ruby193-rubygems \
-      ruby193-ruby-devel \
-      sendmail \
-      unzip \
-      # Necessary for drush
-      which \
-      # Necessary library for phantomjs per https://github.com/ariya/phantomjs/issues/10904
-      fontconfig
+    # Install PHP
+    php70 \
+    php70-php-devel \
+    php70-php-gd \
+    php70-php-xml \
+    php70-php-pdo \
+    php70-php-mysql \
+    php70-php-mysqlnd \
+    php70-php-mbstring \
+    php70-php-fpm \
+    php70-php-opcache \
+    php70-php-pecl-memcache \
+    php70-php-pecl-xdebug \
+    php70-php-mcrypt \
+    # Install Ruby
+    ruby193 \
+    ruby193-rubygems \
+    ruby193-ruby-devel \
+    # Install Miscellaneous Tools
+    bzip2 \
+    gcc-c++ \
+    git2u-all \
+    httpd-tools \
+    jq \
+    make \
+    mariadb \
+    nmap-ncat \
+    patch \
+    postgresql \
+    pv \
+    rsync \
+    sendmail \
+    unzip \
+    # Necessary for drush
+    which \
+    # Necessary library for phantomjs per https://github.com/ariya/phantomjs/issues/10904
+    fontconfig \
+    && yum clean all
 
 # Ensure ruby193 binaries are in path
 ENV PATH /root/.composer/vendor/bin:/opt/rh/ruby193/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -17,43 +17,49 @@ RUN yum -y install \
       https://rpms.remirepo.net/enterprise/remi-release-7.rpm \
     yum -y update
 
+# Add the IUS repository. This is needed for git2.
+RUN curl -L "https://centos7.iuscommunity.org/ius-release.rpm" > /usr/local/ius-release.rpm && \
+    rpm -Uvh /usr/local/ius-release.rpm
+
 RUN yum -y install \
-      bzip2 \
-      gcc-c++ \
-      git \
-      httpd-tools \
-      jq \
-      make \
-      mariadb \
-      nmap-ncat \
-      patch \
-      php71 \
-      php71-php-devel \
-      php71-php-gd \
-      php71-php-xml \
-      php71-php-pdo \
-      php71-php-mysql \
-      php71-php-mysqlnd \
-      php71-php-mbstring \
-      php71-php-fpm \
-      php71-php-opcache \
-      php71-php-pecl-memcache \
-      php71-php-pecl-xdebug \
-      php71-php-mcrypt \
-      # There is no PHP 7 support for XHProf yet.
-      # php71-php-pecl-xhprof \
-      postgresql \
-      pv \
-      rsync \
-      ruby193 \
-      ruby193-rubygems \
-      ruby193-ruby-devel \
-      sendmail \
-      unzip \
-      # Necessary for drush
-      which \
-      # Necessary library for phantomjs per https://github.com/ariya/phantomjs/issues/10904
-      fontconfig
+    # Install PHP
+    php71 \
+    php71-php-devel \
+    php71-php-gd \
+    php71-php-xml \
+    php71-php-pdo \
+    php71-php-mysql \
+    php71-php-mysqlnd \
+    php71-php-mbstring \
+    php71-php-fpm \
+    php71-php-opcache \
+    php71-php-pecl-memcache \
+    php71-php-pecl-xdebug \
+    php71-php-mcrypt \
+    # Install Ruby
+    ruby193 \
+    ruby193-rubygems \
+    ruby193-ruby-devel
+    # Install Miscellaneous Tools
+    bzip2 \
+    gcc-c++ \
+    git2u-all \
+    httpd-tools \
+    jq \
+    make \
+    mariadb \
+    nmap-ncat \
+    patch \
+    postgresql \
+    pv \
+    rsync \
+    sendmail \
+    unzip \
+    # Necessary for drush
+    which \
+    # Necessary library for phantomjs per https://github.com/ariya/phantomjs/issues/10904
+    fontconfig \
+    && yum clean all
 
 # Ensure ruby193 binaries are in path
 ENV PATH /root/.composer/vendor/bin:/opt/rh/ruby193/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -79,6 +85,10 @@ ENV PKG_CONFIG_PATH /opt/rh/ruby193/root/usr/lib64/pkgconfig
 
 # Ensure $HOME is set
 ENV HOME /root
+
+# Configure Git
+# https://git-scm.com/docs/git-config#git-config-corepreloadIndex
+RUN git config --global core.preloadindex true
 
 # Install Composer
 RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/bin/composer


### PR DESCRIPTION
Looks to make the packages and ordering across the Dockerfiles a bit more consistent.

I looked into splitting the installation of PHP & Ruby into a separate layer from the miscellaneous tools to improve caching efficiency, but it increased the image size by about 180MB. We have quite a number of layers in here, seems like some smart consolidation could pay dividends, since we are at 1.35 GB for the php70 image.

Fixes #9 and #22 
