### PR TITLE
Add php-posix for drush site-set command

### DIFF
--- a/php70/Dockerfile
+++ b/php70/Dockerfile
@@ -43,6 +43,7 @@ RUN yum -y install \
       php70-php-opcache \
       php70-php-pecl-memcache \
       php70-php-pecl-xdebug \
+      php70-php-posix \
       php70-php-mcrypt \
       # There is no PHP 7 support for XHProf yet.
       # php70-php-pecl-xhprof \

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -39,6 +39,7 @@ RUN yum -y install \
       php71-php-opcache \
       php71-php-pecl-memcache \
       php71-php-pecl-xdebug \
+      php71-php-posix \
       php71-php-mcrypt \
       # There is no PHP 7 support for XHProf yet.
       # php71-php-pecl-xhprof \


### PR DESCRIPTION
Need the posix support for the "drush site-set" (drush use) command.  Included in the 5.5 and 5.6 versions, but not in the 7.0 and 7.1.