### PR TITLE
Do not process a directory as a key file.

### DIFF
--- a/php55/root/outrigger-key.sh
+++ b/php55/root/outrigger-key.sh
@@ -3,9 +3,10 @@
 KEY_BASE=/root/.ssh
 KEY_FILE=$KEY_BASE/outrigger.key
 
-# First check to see if a volume mounted keyfile with a specific name exists
-# If that file doesn't exit, was the key passed in via an environment variable?
-if [ -e $KEY_FILE ]; then
+# First check to see if a volume mounted keyfile with a specific name exists.
+# If the source on a bind mount does not exist it will be created as an empty directory.
+if [ -e $KEY_FILE ] && [ ! -d $KEY_FILE ]
+then
 
   echo "KEY_FILE found. Setting up key..."
 

--- a/php56/root/outrigger-key.sh
+++ b/php56/root/outrigger-key.sh
@@ -3,9 +3,10 @@
 KEY_BASE=/root/.ssh
 KEY_FILE=$KEY_BASE/outrigger.key
 
-# First check to see if a volume mounted keyfile with a specific name exists
-# If that file doesn't exit, was the key passed in via an environment variable?
-if [ -e $KEY_FILE ]; then
+# First check to see if a volume mounted keyfile with a specific name exists.
+# If the source on a bind mount does not exist it will be created as an empty directory.
+if [ -e $KEY_FILE ] && [ ! -d $KEY_FILE ]
+then
 
   echo "KEY_FILE found. Setting up key..."
 

--- a/php70/root/outrigger-key.sh
+++ b/php70/root/outrigger-key.sh
@@ -3,9 +3,10 @@
 KEY_BASE=/root/.ssh
 KEY_FILE=$KEY_BASE/outrigger.key
 
-# First check to see if a volume mounted keyfile with a specific name exists
-# If that file doesn't exit, was the key passed in via an environment variable?
-if [ -e $KEY_FILE ]; then
+# First check to see if a volume mounted keyfile with a specific name exists.
+# If the source on a bind mount does not exist it will be created as an empty directory.
+if [ -e $KEY_FILE ] && [ ! -d $KEY_FILE ]
+then
 
   echo "KEY_FILE found. Setting up key..."
 

--- a/php71/root/outrigger-key.sh
+++ b/php71/root/outrigger-key.sh
@@ -3,9 +3,10 @@
 KEY_BASE=/root/.ssh
 KEY_FILE=$KEY_BASE/outrigger.key
 
-# First check to see if a volume mounted keyfile with a specific name exists
-# If that file doesn't exit, was the key passed in via an environment variable?
-if [ -e $KEY_FILE ]; then
+# First check to see if a volume mounted keyfile with a specific name exists.
+# If the source on a bind mount does not exist it will be created as an empty directory.
+if [ -e $KEY_FILE ] && [ ! -d $KEY_FILE ]
+then
 
   echo "KEY_FILE found. Setting up key..."
 


### PR DESCRIPTION
If someone accidentally volume mounts a directory as outrigger.key, it will spew some warnings and not work.

If someone bind mounts a source that does not exist, docker will create it as an empty directory.

This fix was originally discussed as part of https://github.com/phase2/docker-jenkins-docker/pull/4