### PR TITLE
Trim & consolidate composer-related operations.

### DIFF
--- a/php55/Dockerfile
+++ b/php55/Dockerfile
@@ -86,14 +86,11 @@ RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/bi
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
-# Install Drush
-RUN composer global require drush/drush:8.x
-
-# Install Prestissimo for composer performance
-RUN composer global require "hirak/prestissimo:^0.3"
-
-# Update composer libraries
-RUN composer global update
+# Add global composer dependencies.
+# Drush for drupal development.
+# prestissimo for parallelized composer download operations.
+RUN composer global require drush/drush:8.x hirak/prestissimo:^0.3 && \
+  composer clear-cache
 
 # Install nvm, supported node versions, and default cli modules.
 ENV NVM_DIR $HOME/.nvm

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -96,14 +96,11 @@ RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/bi
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
-# Install Drush
-RUN composer global require drush/drush:8.x
-
-# Install Prestissimo for composer performance
-RUN composer global require "hirak/prestissimo:^0.3"
-
-# Update composer libraries
-RUN composer global update
+# Add global composer dependencies.
+# Drush for drupal development.
+# prestissimo for parallelized composer download operations.
+RUN composer global require drush/drush:8.x hirak/prestissimo:^0.3 && \
+  composer clear-cache
 
 # Install nvm, supported node versions, and default cli modules.
 ENV NVM_DIR $HOME/.nvm

--- a/php70/Dockerfile
+++ b/php70/Dockerfile
@@ -95,14 +95,11 @@ RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/bi
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
-# Install Drush
-RUN composer global require drush/drush:8.x
-
-# Install Prestissimo for composer performance
-RUN composer global require "hirak/prestissimo:^0.3"
-
-# Update composer libraries
-RUN composer global update
+# Add global composer dependencies.
+# Drush for drupal development.
+# prestissimo for parallelized composer download operations.
+RUN composer global require drush/drush:8.x hirak/prestissimo:^0.3 && \
+  composer clear-cache
 
 # Install nvm, supported node versions, and default cli modules.
 ENV NVM_DIR $HOME/.nvm

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -95,14 +95,11 @@ RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/bi
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
-# Install Drush
-RUN composer global require drush/drush:8.x
-
-# Install Prestissimo for composer performance
-RUN composer global require "hirak/prestissimo:^0.3"
-
-# Update composer libraries
-RUN composer global update
+# Add global composer dependencies.
+# Drush for drupal development.
+# prestissimo for parallelized composer download operations.
+RUN composer global require drush/drush:8.x hirak/prestissimo:^0.3 && \
+  composer clear-cache
 
 # Install nvm, supported node versions, and default cli modules.
 ENV NVM_DIR $HOME/.nvm


### PR DESCRIPTION
1. Consolidate composer requires to a single layer.
2. Add a composer cache-clear to the same layer as the composer require, so we have one lean layer instead of an aggregate image size of something along the lines of Layer 1: +10, Layer 2: -2.
3. Remove composer update. Not sure why we would need to run that.

Branching off the latest master and running the build locally, I found the size dropped from 1397 MB to 1329 MB by a combination of layer consolidation, cache clearing, and removing the composer update operation.

There could be other idiosyncratic issues related to changes in the build environment so we should compare the values by triggering a Docker autobuild to get "harder" numbers.