### PR TITLE
Consolidate nvm layers, add npm cache cleaning, and drop yo.

### DIFF
--- a/php55/Dockerfile
+++ b/php55/Dockerfile
@@ -98,23 +98,28 @@ RUN composer global update
 # Install nvm, supported node versions, and default cli modules.
 ENV NVM_DIR $HOME/.nvm
 ENV NODE_VERSION 4
-RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
+RUN (curl https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash) && \
+  chmod +x $HOME/.nvm/nvm.sh
 
 # Node 4.x (LTS)
-RUN source $NVM_DIR/nvm.sh \
-      && nvm install 4 \
-      && npm install -g bower grunt-cli gulp-cli yo
-# Node 5.x (stable)
-RUN source $NVM_DIR/nvm.sh \
-      && nvm install 5 \
-      && npm install -g bower grunt-cli gulp-cli yo
-# Node 6.x (LTS)
-RUN source $NVM_DIR/nvm.sh \
-      && nvm install 6 \
-      && npm install -g bower grunt-cli gulp-cli yo
+RUN source $NVM_DIR/nvm.sh && \
+  nvm install 4 && \
+  npm install -g bower grunt-cli gulp-cli && \
+  npm cache clean
+# Node 6.x (stable)
+RUN source $NVM_DIR/nvm.sh && \
+  nvm install 6 && \
+  npm install -g bower grunt-cli gulp-cli && \
+  npm cache clean
+# Node 8.x (stable)
+RUN source $NVM_DIR/nvm.sh && \
+  nvm install 8 && \
+  npm install -g bower grunt-cli gulp-cli && \
+  # npm v5 recommends not clearing caches because of improved consistency.
+  # This is not an argument that applies to Docker image layer size.
+  npm cache clean --force
 # Set the default version which can be overridden by ENV.
-RUN source $NVM_DIR/nvm.sh \
-      && nvm alias default $NODE_VERSION
+RUN source $NVM_DIR/nvm.sh && nvm alias default $NODE_VERSION && nvm cache clear
 
 COPY root /
 

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -108,24 +108,28 @@ RUN composer global update
 # Install nvm, supported node versions, and default cli modules.
 ENV NVM_DIR $HOME/.nvm
 ENV NODE_VERSION 4
-RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
+RUN (curl https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash) && \
+  chmod +x $HOME/.nvm/nvm.sh
 
 # Node 4.x (LTS)
-RUN source $NVM_DIR/nvm.sh \
-      && nvm install 4 \
-      && npm install -g bower grunt-cli gulp-cli yo
-# Node 5.x (stable)
-RUN source $NVM_DIR/nvm.sh \
-      && nvm install 5 \
-      && npm install -g bower grunt-cli gulp-cli yo
-# Node 6.x (LTS)
-RUN source $NVM_DIR/nvm.sh \
-      && nvm install 6 \
-      && npm install -g bower grunt-cli gulp-cli yo
+RUN source $NVM_DIR/nvm.sh && \
+  nvm install 4 && \
+  npm install -g bower grunt-cli gulp-cli && \
+  npm cache clean
+# Node 6.x (stable)
+RUN source $NVM_DIR/nvm.sh && \
+  nvm install 6 && \
+  npm install -g bower grunt-cli gulp-cli && \
+  npm cache clean
+# Node 8.x (stable)
+RUN source $NVM_DIR/nvm.sh && \
+  nvm install 8 && \
+  npm install -g bower grunt-cli gulp-cli && \
+  # npm v5 recommends not clearing caches because of improved consistency.
+  # This is not an argument that applies to Docker image layer size.
+  npm cache clean --force
 # Set the default version which can be overridden by ENV.
-RUN source $NVM_DIR/nvm.sh \
-      && nvm alias default $NODE_VERSION
-RUN source $NVM_DIR/nvm.sh && nvm cache clear
+RUN source $NVM_DIR/nvm.sh && nvm alias default $NODE_VERSION && nvm cache clear
 
 COPY root /
 

--- a/php70/Dockerfile
+++ b/php70/Dockerfile
@@ -107,25 +107,28 @@ RUN composer global update
 # Install nvm, supported node versions, and default cli modules.
 ENV NVM_DIR $HOME/.nvm
 ENV NODE_VERSION 4
-RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
-RUN chmod +x $HOME/.nvm/nvm.sh
+RUN (curl https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash) && \
+  chmod +x $HOME/.nvm/nvm.sh
 
 # Node 4.x (LTS)
-RUN source $NVM_DIR/nvm.sh \
-      && nvm install 4 \
-      && npm install -g bower grunt-cli gulp-cli yo
+RUN source $NVM_DIR/nvm.sh && \
+  nvm install 4 && \
+  npm install -g bower grunt-cli gulp-cli && \
+  npm cache clean
 # Node 6.x (stable)
-RUN source $NVM_DIR/nvm.sh \
-      && nvm install 6 \
-      && npm install -g bower grunt-cli gulp-cli yo
+RUN source $NVM_DIR/nvm.sh && \
+  nvm install 6 && \
+  npm install -g bower grunt-cli gulp-cli && \
+  npm cache clean
 # Node 8.x (stable)
-RUN source $NVM_DIR/nvm.sh \
-      && nvm install 8 \
-      && npm install -g bower grunt-cli gulp-cli yo
+RUN source $NVM_DIR/nvm.sh && \
+  nvm install 8 && \
+  npm install -g bower grunt-cli gulp-cli && \
+  # npm v5 recommends not clearing caches because of improved consistency.
+  # This is not an argument that applies to Docker image layer size.
+  npm cache clean --force
 # Set the default version which can be overridden by ENV.
-RUN source $NVM_DIR/nvm.sh \
-      && nvm alias default $NODE_VERSION
-RUN source $NVM_DIR/nvm.sh && nvm cache clear
+RUN source $NVM_DIR/nvm.sh && nvm alias default $NODE_VERSION && nvm cache clear
 
 COPY root /
 

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -107,25 +107,28 @@ RUN composer global update
 # Install nvm, supported node versions, and default cli modules.
 ENV NVM_DIR $HOME/.nvm
 ENV NODE_VERSION 4
-RUN curl https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
-RUN chmod +x $HOME/.nvm/nvm.sh
+RUN (curl https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash) && \
+  chmod +x $HOME/.nvm/nvm.sh
 
 # Node 4.x (LTS)
-RUN source $NVM_DIR/nvm.sh \
-      && nvm install 4 \
-      && npm install -g bower grunt-cli gulp-cli yo
-# Node 6.x (LTS)
-RUN source $NVM_DIR/nvm.sh \
-      && nvm install 6 \
-      && npm install -g bower grunt-cli gulp-cli yo
-# Node 8.x (LTS)
-RUN source $NVM_DIR/nvm.sh \
-      && nvm install 8 \
-      && npm install -g bower grunt-cli gulp-cli yo
+RUN source $NVM_DIR/nvm.sh && \
+  nvm install 4 && \
+  npm install -g bower grunt-cli gulp-cli && \
+  npm cache clean
+# Node 6.x (stable)
+RUN source $NVM_DIR/nvm.sh && \
+  nvm install 6 && \
+  npm install -g bower grunt-cli gulp-cli && \
+  npm cache clean
+# Node 8.x (stable)
+RUN source $NVM_DIR/nvm.sh && \
+  nvm install 8 && \
+  npm install -g bower grunt-cli gulp-cli && \
+  # npm v5 recommends not clearing caches because of improved consistency.
+  # This is not an argument that applies to Docker image layer size.
+  npm cache clean --force
 # Set the default version which can be overridden by ENV.
-RUN source $NVM_DIR/nvm.sh \
-      && nvm alias default $NODE_VERSION
-RUN source $NVM_DIR/nvm.sh && nvm cache clear
+RUN source $NVM_DIR/nvm.sh && nvm alias default $NODE_VERSION && nvm cache clear
 
 COPY root /
 


### PR DESCRIPTION
Drops 1397 MB from the current upstream version to 1238 MB.

1. Consolidate nvm layers.
2. Add npm cache clean to the end of each npm install step.
3. Drop global install of `yo`, since it doesn't work in the build container anyway.
4. As a secondary maneuver, this removes node v5 from the php55 image, and adds in node v8.

This does point to a need to better support patterlab-starter themes by facilitating the use of generators shipped as part of the theme, which are currently expected to operate via an npm script: `npm run new`.