### PR TITLE
Allow bower and npm to run as root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ offered by this image.
   to make available to all tools via nvm. The latest minor release as of the image build will be used.
 * `PHP_XDEBUG`: [`"true"`|`"false"`] Specify whether the PHP Xdebug extension should be enabled.
 
+### Default Tools Configuration
+
+A number of tools that are built into the Build image can be further configured by environment variables. These can be overridden
+by your `docker run` command or your docker-compose configuration. For more details on these variables or other environment variable
+options, check the configuration documentation for individual tools.
+
+* **Composer**:
+    * `COMPOSER_ALLOW_SUPERUSER`: [`1`] Run composer as the root user.
+* **npm**:
+    * `NPM_CONFIG_UNSAFE_PERM`: [`true`] Run npm commands with the --unsafe-perm flag. This makes behavior of running npm as root more consistent when using npm scripts that call other npm scripts.
+* **bower**:
+    * `BOWER_ALLOW_ROOT`: [`true`] Bower will refuse to execute when run as root without the --allow-root flag. This sets that as a persisting configuration.
+
+Unless you are modifying a customized Build image to run as a user other than **root** you will not need to change these.
+
 ## Maintainers
 
 [![Phase2 Logo](https://s3.amazonaws.com/phase2.public/logos/phase2-logo.png)](https://www.phase2technology.com)

--- a/php55/Dockerfile
+++ b/php55/Dockerfile
@@ -118,6 +118,11 @@ RUN source $NVM_DIR/nvm.sh && \
 # Set the default version which can be overridden by ENV.
 RUN source $NVM_DIR/nvm.sh && nvm alias default $NODE_VERSION && nvm cache clear
 
+# Configure npm for container life.
+ENV NPM_CONFIG_UNSAFE_PERM true
+# Configure bower for container life.
+ENV BOWER_ALLOW_ROOT true
+
 COPY root /
 
 # Install Drush commands

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -128,6 +128,11 @@ RUN source $NVM_DIR/nvm.sh && \
 # Set the default version which can be overridden by ENV.
 RUN source $NVM_DIR/nvm.sh && nvm alias default $NODE_VERSION && nvm cache clear
 
+# Configure npm for container life.
+ENV NPM_CONFIG_UNSAFE_PERM true
+# Configure bower for container life.
+ENV BOWER_ALLOW_ROOT true
+
 COPY root /
 
 # Install Drush commands

--- a/php70/Dockerfile
+++ b/php70/Dockerfile
@@ -127,6 +127,11 @@ RUN source $NVM_DIR/nvm.sh && \
 # Set the default version which can be overridden by ENV.
 RUN source $NVM_DIR/nvm.sh && nvm alias default $NODE_VERSION && nvm cache clear
 
+# Configure npm for container life.
+ENV NPM_CONFIG_UNSAFE_PERM true
+# Configure bower for container life.
+ENV BOWER_ALLOW_ROOT true
+
 COPY root /
 
 # Install Drush commands

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -127,6 +127,11 @@ RUN source $NVM_DIR/nvm.sh && \
 # Set the default version which can be overridden by ENV.
 RUN source $NVM_DIR/nvm.sh && nvm alias default $NODE_VERSION && nvm cache clear
 
+# Configure npm for container life.
+ENV NPM_CONFIG_UNSAFE_PERM true
+# Configure bower for container life.
+ENV BOWER_ALLOW_ROOT true
+
 COPY root /
 
 # Install Drush commands


### PR DESCRIPTION
I successfully tested that the bower env var replaces the need to run `bower --allow-root`. The NPM config change should replace the need to run npm install with `--unsafe-perm`, but while I found existing use of that var I had trouble testing it -- maybe it's not a problem in npm v3?.

Both of these are a source of friction related to running the tools as root. By setting these as environment variables, the Docker image allows developers to use the tools a bit more transparently.

Pinging a couple frontend developers to confirm that this wouldn't be a WTF. @tjheffner @anniegreens 