### PR TITLE
Set remote_host for xdebug to gateway IP for docker vm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ offered by this image.
 
 * `NODE_VERSION`: [`4`|`6`|`8`] Defaults to 4. Selects the major version of Node
   to make available to all tools via nvm. The latest minor release as of the image build will be used.
-* `PHP_XDEBUG`: [`"true"`|`"false"`] Specify whether the PHP Xdebug extension should be enabled.
+* `PHP_XDEBUG`: [`"true"`|`"false"`] Specify whether the PHP Xdebug extension should be enabled. Xdebug is configured to autostart on script execution and attempt to use a remote connection to 192.168.99.1 on port 9000.
+* `XDEBUG_CONFIG`: This can be used to override many of the Xdebug remote settings. You can find documentation of this variable at [https://xdebug.org/docs/remote](https://xdebug.org/docs/remote). By default this variable is not set as all needed configuration is set within the .ini file. An example setting to override the remote host and port would be `"remote_host=172.17.0.1 remote_port=9999"`.
 
 ### Default Tools Configuration
 

--- a/php56/root/etc/confd/templates/xdebug.ini.tmpl
+++ b/php56/root/etc/confd/templates/xdebug.ini.tmpl
@@ -11,7 +11,8 @@ xdebug.remote_enable=1
 xdebug.remote_autostart=1
 xdebug.remote_connect_back=1
 ; If the following remote_host value does not work use the environmental
-; variable XDEBUG_CONFIG to override it
+; variable XDEBUG_CONFIG to override it. Documentation for format at
+; https://xdebug.org/docs/remote
 xdebug.remote_host=192.168.99.1
 xdebug.remote_port=9000
 xdebug.remote_handler=dbgp

--- a/php56/root/etc/confd/templates/xdebug.ini.tmpl
+++ b/php56/root/etc/confd/templates/xdebug.ini.tmpl
@@ -8,12 +8,14 @@ xdebug.coverage_enable=0
 xdebug.default_enable=1
 
 xdebug.remote_enable=1
+xdebug.remote_autostart=1
 xdebug.remote_connect_back=1
-xdebug.remote_host=localhost
+; If the following remote_host value does not work use the environmental
+; variable XDEBUG_CONFIG to override it
+xdebug.remote_host=192.168.99.1
 xdebug.remote_port=9000
 xdebug.remote_handler=dbgp
 xdebug.remote_log=/tmp/xdebug.log
-xdebug.remote_autostart=true
 
 xdebug.idekey="DEVTOOLS"
 

--- a/php70/root/etc/confd/templates/xdebug.ini.tmpl
+++ b/php70/root/etc/confd/templates/xdebug.ini.tmpl
@@ -11,7 +11,8 @@ xdebug.remote_enable=1
 xdebug.remote_autostart=1
 xdebug.remote_connect_back=1
 ; If the following remote_host value does not work use the environmental
-; variable XDEBUG_CONFIG to override it
+; variable XDEBUG_CONFIG to override it. Documentation for format at
+; https://xdebug.org/docs/remote
 xdebug.remote_host=192.168.99.1
 xdebug.remote_port=9000
 xdebug.remote_handler=dbgp

--- a/php70/root/etc/confd/templates/xdebug.ini.tmpl
+++ b/php70/root/etc/confd/templates/xdebug.ini.tmpl
@@ -8,12 +8,14 @@ xdebug.coverage_enable=0
 xdebug.default_enable=1
 
 xdebug.remote_enable=1
+xdebug.remote_autostart=1
 xdebug.remote_connect_back=1
-xdebug.remote_host=localhost
+; If the following remote_host value does not work use the environmental
+; variable XDEBUG_CONFIG to override it
+xdebug.remote_host=192.168.99.1
 xdebug.remote_port=9000
 xdebug.remote_handler=dbgp
 xdebug.remote_log=/tmp/xdebug.log
-xdebug.remote_autostart=true
 
 xdebug.idekey="DEVTOOLS"
 

--- a/php71/root/etc/confd/templates/xdebug.ini.tmpl
+++ b/php71/root/etc/confd/templates/xdebug.ini.tmpl
@@ -11,7 +11,8 @@ xdebug.remote_enable=1
 xdebug.remote_autostart=1
 xdebug.remote_connect_back=1
 ; If the following remote_host value does not work use the environmental
-; variable XDEBUG_CONFIG to override it
+; variable XDEBUG_CONFIG to override it. Documentation for format at
+; https://xdebug.org/docs/remote
 xdebug.remote_host=192.168.99.1
 xdebug.remote_port=9000
 xdebug.remote_handler=dbgp

--- a/php71/root/etc/confd/templates/xdebug.ini.tmpl
+++ b/php71/root/etc/confd/templates/xdebug.ini.tmpl
@@ -8,12 +8,14 @@ xdebug.coverage_enable=0
 xdebug.default_enable=1
 
 xdebug.remote_enable=1
+xdebug.remote_autostart=1
 xdebug.remote_connect_back=1
-xdebug.remote_host=localhost
+; If the following remote_host value does not work use the environmental
+; variable XDEBUG_CONFIG to override it
+xdebug.remote_host=192.168.99.1
 xdebug.remote_port=9000
 xdebug.remote_handler=dbgp
 xdebug.remote_log=/tmp/xdebug.log
-xdebug.remote_autostart=true
 
 xdebug.idekey="DEVTOOLS"
 


### PR DESCRIPTION
This should allow xdebug to work by default for connecting back to a
host IDE for anyone whose VM spins up in the 192.168.99.x ip space.

Related to PR https://github.com/phase2/generator-outrigger-drupal/pull/51/files

Change in positioning and value of autostart is to align it with other booleans in terms of specifying a true value and grouping it with the other related booleans for this part of xdebug functionality.