### PR TITLE
Update PHP config file location references

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [`php56` (*php56/Dockerfile*)](https://github.com/phase2/docker-build/blob/master/php56/Dockerfile) [![](https://images.microbadger.com/badges/image/outrigger/build:php56.svg)](https://microbadger.com/images/outrigger/build:php56 "Get your own image badge on microbadger.com")
 - [`php70` (*php70/Dockerfile*)](https://github.com/phase2/docker-build/blob/master/php70/Dockerfile) [![](https://images.microbadger.com/badges/image/outrigger/build:php70.svg)](https://microbadger.com/images/outrigger/build:php70 "Get your own image badge on microbadger.com")
 - [`php71` (*php71/Dockerfile*)](https://github.com/phase2/docker-build/blob/master/php71/Dockerfile) [![](https://images.microbadger.com/badges/image/outrigger/build:php71.svg)](https://microbadger.com/images/outrigger/build:php71 "Get your own image badge on microbadger.com")
+- [`php72` (*php71/Dockerfile*)](https://github.com/phase2/docker-build/blob/master/php72/Dockerfile) [![](https://images.microbadger.com/badges/image/outrigger/build:php72.svg)](https://microbadger.com/images/outrigger/build:php72 "Get your own image badge on microbadger.com")
 
 This image provides the many development tools necessary to build applications
 the Outrigger way, bundled with a wide array of tools useful for development and

--- a/php71/root/etc/confd/conf.d/xdebug.ini.toml
+++ b/php71/root/etc/confd/conf.d/xdebug.ini.toml
@@ -1,6 +1,6 @@
 [template]
 src = "xdebug.ini.tmpl"
-dest = "/etc/opt/remi/php70/php.d/15-xdebug.ini"
+dest = "/etc/opt/remi/php71/php.d/15-xdebug.ini"
 uid = 0
 gid = 0
 mode = "0644"

--- a/php71/root/etc/opt/remi/php71/php.d/10-opcache.ini
+++ b/php71/root/etc/opt/remi/php71/php.d/10-opcache.ini
@@ -58,7 +58,7 @@ opcache.fast_shutdown=1
 ; The location of the OPcache blacklist file (wildcards allowed).
 ; Each OPcache blacklist file is a text file that holds the names of files
 ; that should not be accelerated.
-opcache.blacklist_filename=/etc/opt/remi/php70/php.d/opcache*.blacklist
+opcache.blacklist_filename=/etc/opt/remi/php71/php.d/opcache*.blacklist
 
 ; Allows exclusion of large files from being cached. By default all files
 ; are cached.
@@ -96,8 +96,8 @@ opcache.blacklist_filename=/etc/opt/remi/php70/php.d/opcache*.blacklist
 ; It should improve performance when SHM memory is full, at server restart or
 ; SHM reset. The default "" disables file based caching.
 ; RPM note : file cache directory must be owned by process owner
-;   for mod_php, see /etc/opt/remi/php70/httpd/conf.d/php.conf
-;   for php-fpm, see /etc/opt/remi/php70/php-fpm.d/*conf
+;   for mod_php, see /etc/opt/remi/php71/httpd/conf.d/php.conf
+;   for php-fpm, see /etc/opt/remi/php71/php-fpm.d/*conf
 ;opcache.file_cache=
 
 ; Enables or disables opcode caching in shared memory.

--- a/php72/root/etc/confd/conf.d/xdebug.ini.toml
+++ b/php72/root/etc/confd/conf.d/xdebug.ini.toml
@@ -1,6 +1,6 @@
 [template]
 src = "xdebug.ini.tmpl"
-dest = "/etc/opt/remi/php70/php.d/15-xdebug.ini"
+dest = "/etc/opt/remi/php72/php.d/15-xdebug.ini"
 uid = 0
 gid = 0
 mode = "0644"

--- a/php72/root/etc/opt/remi/php72/php.d/10-opcache.ini
+++ b/php72/root/etc/opt/remi/php72/php.d/10-opcache.ini
@@ -58,7 +58,7 @@ opcache.fast_shutdown=1
 ; The location of the OPcache blacklist file (wildcards allowed).
 ; Each OPcache blacklist file is a text file that holds the names of files
 ; that should not be accelerated.
-opcache.blacklist_filename=/etc/opt/remi/php70/php.d/opcache*.blacklist
+opcache.blacklist_filename=/etc/opt/remi/php72/php.d/opcache*.blacklist
 
 ; Allows exclusion of large files from being cached. By default all files
 ; are cached.
@@ -96,8 +96,8 @@ opcache.blacklist_filename=/etc/opt/remi/php70/php.d/opcache*.blacklist
 ; It should improve performance when SHM memory is full, at server restart or
 ; SHM reset. The default "" disables file based caching.
 ; RPM note : file cache directory must be owned by process owner
-;   for mod_php, see /etc/opt/remi/php70/httpd/conf.d/php.conf
-;   for php-fpm, see /etc/opt/remi/php70/php-fpm.d/*conf
+;   for mod_php, see /etc/opt/remi/php72/httpd/conf.d/php.conf
+;   for php-fpm, see /etc/opt/remi/php72/php-fpm.d/*conf
 ;opcache.file_cache=
 
 ; Enables or disables opcode caching in shared memory.


### PR DESCRIPTION
Some paths in the 7.1 and 7.2 directories still used values from 7.0. Fixes those and adds information about the availability of 7.2 to the README.